### PR TITLE
Refactoring API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ You can either specify a configuration via _--config_ or set configuration via E
 ### Yaml configuration
 
 ```YAML
+timeout: Timeout in seconds for the validator, defines maximum runtime. (default: 0)
+
 qontract: 
   serverurl: URL to the GraphQL API. REQUIRED
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ vault:
 
 user_validator:
   concurrency: Number of coroutines to use to query Github (default: 10)
-  github_api_timeout: Timeout in seconds for Github request (default: 60s)
+
+github
+  timeout: Timeout in seconds for Github request (default: 60s)
 ```
 
 ### Environment variables
@@ -37,7 +39,7 @@ Instead of using a yaml file, all parameters can be set via environment variable
  * VAULT_ROLE_ID
  * VAULT_SECRET_ID
  * USER_VALIDATOR_CONCURRENCY
- * USER_VALIDATOR_GITHUB_API_TIMEOUT
+ * GITHUB_API_TIMEOUT
 
 ## Licence
 [Apache License Version 2.0](LICENSE).

--- a/cmd/user_validator.go
+++ b/cmd/user_validator.go
@@ -3,11 +3,10 @@ package cmd
 import (
 	"github.com/janboll/user-validator/internal"
 	. "github.com/janboll/user-validator/pkg"
-	"github.com/spf13/viper"
 )
 
 func userValidator() {
-	validator := internal.NewValidateUser(internal.NewValidateUserConfig(viper.GetViper()), NewRunnerConfig(nil))
+	validator := internal.NewValidateUser()
 	runner := NewValidationRunner(validator)
 	err := runner.Run()
 	if err != nil {

--- a/example.yml
+++ b/example.yml
@@ -1,5 +1,3 @@
-timeout: 3
-
 qontract: 
   serverurl: "http://localhost:4000/graphql"
 

--- a/example.yml
+++ b/example.yml
@@ -1,3 +1,5 @@
+timeout: 3
+
 qontract: 
   serverurl: "http://localhost:4000/graphql"
 

--- a/internal/user_validator.go
+++ b/internal/user_validator.go
@@ -184,16 +184,15 @@ func (i *ValidateUser) validateUsersSinglePath(users queries.UsersResponse) []Va
 
 func (i *ValidateUser) getAndValidateUser(ctx context.Context, user queries.UsersUsers_v1User_v1) *ValidationError {
 	Log().Debugw("Getting github user", "user", user.GetOrg_username())
-	ghUser := i.AuthenticatedGithubClient.GetUsers(ctx, user.GetGithub_username())
-	// if err != nil {
-	// 	Log().Debugw("API error", "user", user.Org_username, "error", err.Error())
-	// 	return &ValidationError{
-	// 		Path:       user.Path,
-	// 		Validation: "validateUsersGithub",
-	// 		Error:      err,
-	// 	}
-	// } else
-	if ghUser.GetLogin() != user.GetGithub_username() {
+	ghUser, err := i.AuthenticatedGithubClient.GetUsers(ctx, user.GetGithub_username())
+	if err != nil {
+		Log().Debugw("API error", "user", user.Org_username, "error", err.Error())
+		return &ValidationError{
+			Path:       user.Path,
+			Validation: "validateUsersGithub",
+			Error:      err,
+		}
+	} else if ghUser.GetLogin() != user.GetGithub_username() {
 		return &ValidationError{
 			Path:       user.Path,
 			Validation: "validateUsersGithub",

--- a/pkg/github.go
+++ b/pkg/github.go
@@ -4,16 +4,47 @@ import (
 	"context"
 
 	"github.com/google/go-github/v42/github"
+	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
 
-// NewAuthedGithubClient creates a Github client with custom oauth2 client
-func NewAuthedGithubClient(ctx *context.Context, token string) *github.Client {
+// AuthenticatedGithubClient is an oauth2 using Github API client
+type AuthenticatedGithubClient struct {
+	GithubClient *github.Client
+}
 
+// GithubClientConfig holds configuration GithubClient
+type GithubClientConfig struct {
+	Timeout int
+	BaseURL string
+}
+
+// NewGithubClientConfig creates a new GithubClientConfig from viper
+func NewGithubClientConfig(v *viper.Viper) *GithubClientConfig {
+	var qc GithubClientConfig
+	sub := EnsureViperSub(v, "github")
+	sub.SetDefault("timeout", 60)
+	sub.BindEnv("baseurl", "GITHUB_API")
+	sub.BindEnv("timeout", "GITHUB_API_TIMEOUT")
+	if err := sub.Unmarshal(&qc); err != nil {
+		Log().Fatalw("Error while unmarshalling configuration %s", err.Error())
+	}
+	return &qc
+}
+
+// NewAuthenticatedGithubClient creates a Github client with custom oauth2 client
+func NewAuthenticatedGithubClient(ctx context.Context, token string) *AuthenticatedGithubClient {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
-	tc := oauth2.NewClient(*ctx, ts)
+	tc := oauth2.NewClient(ctx, ts)
 
-	return github.NewClient(tc)
+	return &AuthenticatedGithubClient{
+		GithubClient: github.NewClient(tc),
+	}
+}
+
+func (c *AuthenticatedGithubClient) GetUsers(ctx context.Context, user string) *github.User {
+	ghUser, _, _ := c.GithubClient.Users.Get(ctx, user)
+	return ghUser
 }

--- a/pkg/github.go
+++ b/pkg/github.go
@@ -44,7 +44,7 @@ func NewAuthenticatedGithubClient(ctx context.Context, token string) *Authentica
 	}
 }
 
-func (c *AuthenticatedGithubClient) GetUsers(ctx context.Context, user string) *github.User {
-	ghUser, _, _ := c.GithubClient.Users.Get(ctx, user)
-	return ghUser
+func (c *AuthenticatedGithubClient) GetUsers(ctx context.Context, user string) (*github.User, error) {
+	ghUser, _, err := c.GithubClient.Users.Get(ctx, user)
+	return ghUser, err
 }

--- a/pkg/github_test.go
+++ b/pkg/github_test.go
@@ -10,6 +10,6 @@ import (
 func TestNewAuthedGithubClient(t *testing.T) {
 	ctx := context.Background()
 	token := "FOOBAR"
-	client := NewAuthedGithubClient(&ctx, token)
+	client := NewAuthenticatedGithubClient(ctx, token)
 	assert.NotNil(t, client)
 }

--- a/pkg/qontract_client.go
+++ b/pkg/qontract_client.go
@@ -10,17 +10,16 @@ import (
 // QontractClient abstraction for generated GraphQL client
 type QontractClient struct {
 	Client graphql.Client
+	config *qontractConfig
 }
 
-// QontractConfig is used to unmarshal yaml configuration for GQL Clients
-type QontractConfig struct {
+type qontractConfig struct {
 	ServerURL string
 }
 
-// NewQontractConfig creates a new Qontractconfig from viper
-func NewQontractConfig(v *viper.Viper) *QontractConfig {
-	var qc QontractConfig
-	sub := EnsureViperSub(v, "qontract")
+func newQontractConfig() *qontractConfig {
+	var qc qontractConfig
+	sub := EnsureViperSub(viper.GetViper(), "qontract")
 	sub.BindEnv("serverurl", "QONTRACT_SERVER_URL")
 	if err := sub.Unmarshal(&qc); err != nil {
 		Log().Fatalw("Error while unmarshalling configuration %s", err.Error())
@@ -29,8 +28,10 @@ func NewQontractConfig(v *viper.Viper) *QontractConfig {
 }
 
 // NewQontractClient creates a new QontractClient
-func NewQontractClient(config *QontractConfig) *QontractClient {
+func NewQontractClient() *QontractClient {
+	config := newQontractConfig()
 	return &QontractClient{
 		Client: graphql.NewClient(config.ServerURL, http.DefaultClient),
+		config: config,
 	}
 }

--- a/pkg/qontract_client_test.go
+++ b/pkg/qontract_client_test.go
@@ -8,37 +8,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func qontractSetupViper() *viper.Viper {
-	v := viper.New()
+func qontractSetupViper() {
+	v := viper.GetViper()
 
 	qontractCfg := make(map[string]interface{})
 	qontractCfg["serverurl"] = "http://conf.example"
 
 	v.Set("qontract", qontractCfg)
-	return v
-}
-
-func qontractSetupViperEnv() *viper.Viper {
-	v := viper.New()
-	os.Setenv("QONTRACT_SERVER_URL", "http://env.example")
-
-	qontractCfg := make(map[string]interface{})
-	v.Set("qontract", qontractCfg)
-	return v
 }
 
 func TestNewQontractClient(t *testing.T) {
-	qc := NewQontractConfig(qontractSetupViper())
-	assert.Equal(t, "http://conf.example", qc.ServerURL)
+	qontractSetupViper()
 
-	client := NewQontractClient(qc)
+	client := NewQontractClient()
+	assert.Equal(t, "http://conf.example", client.config.ServerURL)
 	assert.NotNil(t, client)
 }
 
 func TestNewQontractClientEnv(t *testing.T) {
-	qc := NewQontractConfig(qontractSetupViperEnv())
-	assert.Equal(t, "http://env.example", qc.ServerURL)
+	qontractSetupViper()
+	os.Setenv("QONTRACT_SERVER_URL", "http://env.example")
 
-	client := NewQontractClient(qc)
+	client := NewQontractClient()
+	assert.Equal(t, "http://env.example", client.config.ServerURL)
 	assert.NotNil(t, client)
 }

--- a/pkg/reconcile_test.go
+++ b/pkg/reconcile_test.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -19,7 +20,7 @@ type TestValidation struct {
 	ValidateError bool
 }
 
-func (t *TestValidation) Setup() error {
+func (t *TestValidation) Setup(ctx context.Context) error {
 	if t.SetupError {
 		return fmt.Errorf("Error during setup")
 	}
@@ -27,7 +28,7 @@ func (t *TestValidation) Setup() error {
 	return nil
 }
 
-func (t *TestValidation) Validate() ([]ValidationError, error) {
+func (t *TestValidation) Validate(ctx context.Context) ([]ValidationError, error) {
 	if t.ValidateError {
 		return nil, fmt.Errorf("Error during validate")
 	}
@@ -128,6 +129,6 @@ func reconcileSetupViper() *viper.Viper {
 }
 
 func TestNewRunnerConfig(t *testing.T) {
-	runnerConfg := NewRunnerConfig(reconcileSetupViper())
+	runnerConfg := newRunnerConfig()
 	assert.False(t, runnerConfg.DryRun)
 }

--- a/pkg/vault.go
+++ b/pkg/vault.go
@@ -12,8 +12,7 @@ type VaultClient struct {
 	client *api.Client
 }
 
-// VaultConfig is used to unmarshal yaml configuration for VaultClients
-type VaultConfig struct {
+type vaultConfig struct {
 	Addr     string
 	AuthType string
 	Token    string
@@ -21,10 +20,9 @@ type VaultConfig struct {
 	SecretID string
 }
 
-// NewVaultConfig creates a new VaultConfig from viper configuration
-func NewVaultConfig(v *viper.Viper) *VaultConfig {
-	var vc VaultConfig
-	sub := EnsureViperSub(v, "vault")
+func newVaultConfig() *vaultConfig {
+	var vc vaultConfig
+	sub := EnsureViperSub(viper.GetViper(), "vault")
 	sub.BindEnv("addr", "VAULT_ADDR")
 	sub.BindEnv("authtype", "VAULT_AUTHTYPE")
 	sub.BindEnv("token", "VAULT_TOKEN")
@@ -37,7 +35,8 @@ func NewVaultConfig(v *viper.Viper) *VaultConfig {
 }
 
 // NewVaultClient creates a new VaultClient from a VaultConfig
-func NewVaultClient(vc *VaultConfig) (*VaultClient, error) {
+func NewVaultClient() (*VaultClient, error) {
+	vc := newVaultConfig()
 	vaultClient := &VaultClient{}
 	vaultCFG := api.DefaultConfig()
 	vaultCFG.Address = vc.Addr
@@ -66,7 +65,7 @@ func NewVaultClient(vc *VaultConfig) (*VaultClient, error) {
 		vaultClient.client.SetToken(vc.Token)
 
 	default:
-		return nil, fmt.Errorf("Unsupported auth type \"%s\"", vc.AuthType)
+		return nil, fmt.Errorf("unsupported auth type \"%s\"", vc.AuthType)
 	}
 
 	return vaultClient, nil


### PR DESCRIPTION
* Getting context straight: moving context to function parameters, wehere
  required and removing it from objects, as per best practices.
* Making the API simpler by remove need to call NewConfig* constructors.
  These will now be called by the correspondig New constructors.
* Fixing typos in config and moving Github config into seperate config
  instance.