### PR TITLE
APPSRE-4839 Fixes for unleash implementation

### DIFF
--- a/pkg/reconcile.go
+++ b/pkg/reconcile.go
@@ -117,10 +117,6 @@ func (v *ValidationRunner) Run() {
 		ctx, cancel = context.WithCancel(ctx)
 	}
 	defer cancel()
-	if err := v.Runnable.Setup(ctx); err != nil {
-		Log().Errorw("Error during integration", "error", err.Error())
-		v.Exiter(1)
-	}
 
 	if v.config.UseFeatureToggle {
 		enabled, err := isFeatureEnabled(ctx, v.Name)
@@ -132,6 +128,11 @@ func (v *ValidationRunner) Run() {
 			Log().Warnw("Integration not enabled")
 			v.Exiter(0)
 		}
+	}
+
+	if err := v.Runnable.Setup(ctx); err != nil {
+		Log().Errorw("Error during integration", "error", err.Error())
+		v.Exiter(1)
 	}
 
 	validationErrors, err := v.Runnable.Validate(ctx)

--- a/pkg/unleash.go
+++ b/pkg/unleash.go
@@ -71,7 +71,7 @@ func NewUnleashClient() (*UnleashClient, error) {
 // Dept: split up this method if you add new URLs, do not just copy and paste it!
 func (c *UnleashClient) GetFeature(ctx context.Context, name string) (*Feature, error) {
 	Log().Debugw("Checking if feature is enabled", "feature", name)
-	path := fmt.Sprintf("%s/api/client/features/%s", c.unleashConfig.ApiUrl, name)
+	path := fmt.Sprintf("%s/client/features/%s", c.unleashConfig.ApiUrl, name)
 	req, err := http.NewRequestWithContext(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/unleash_test.go
+++ b/pkg/unleash_test.go
@@ -37,7 +37,7 @@ func TestGetFeature(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, fmt.Sprintf("Bearer %s", token), r.Header.Get("Authorization"))
-			assert.Equal(t, r.URL.Path, "/api/client/features/test")
+			assert.Equal(t, r.URL.Path, "/client/features/test")
 			w.Write([]byte(`{"enabled":true,"name":"test","project":"default","type":"release"}`))
 		}))
 


### PR DESCRIPTION
/api suffix is provided in the env variable, remove from path generation

Only run setup if integration is enabled