### PR TITLE
Remove deprecated io/ioutil package

### DIFF
--- a/internal/user_validator_test.go
+++ b/internal/user_validator_test.go
@@ -3,9 +3,10 @@ package internal
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/app-sre/user-validator/internal/queries"
@@ -21,7 +22,7 @@ var (
 )
 
 func readKeyFile(t *testing.T, fileName string) []byte {
-	key, err := ioutil.ReadFile(fileName)
+	key, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("Could not read public key test data %s, error: %s", fileName, err.Error())
 	}
@@ -152,7 +153,7 @@ func TestValidateValidateUsersSinglePathValid(t *testing.T) {
 func createGithubUsersMock(t *testing.T, retBody string, retCode int) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "/api/v3/users")
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		assert.Nil(t, err)
 
 		fmt.Fprint(w, retBody)

--- a/pkg/gql/qontract_client_test.go
+++ b/pkg/gql/qontract_client_test.go
@@ -2,7 +2,7 @@ package gql
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -127,7 +127,7 @@ func TestIntegrationsCalled(t *testing.T) {
 	var extensionsQueried bool
 	mock := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			b, _ := ioutil.ReadAll(r.Body)
+			b, _ := io.ReadAll(r.Body)
 			if pkg.Contains(expected_queries, string(b)) {
 				extensionsQueried = true
 			}

--- a/pkg/unleash.go
+++ b/pkg/unleash.go
@@ -3,7 +3,7 @@ package pkg
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func (c *UnleashClient) GetFeature(ctx context.Context, name string) (*Feature, 
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vault_test.go
+++ b/pkg/vault_test.go
@@ -2,7 +2,7 @@ package pkg
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -84,7 +84,7 @@ func TestNewVaultClientAppRole(t *testing.T) {
 	mockedToken := "65b74ffd-842c-fd43-1386-f7d7006e520a"
 	vaultMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "auth/approle/login")
-		sentBody, err := ioutil.ReadAll(r.Body)
+		sentBody, err := io.ReadAll(r.Body)
 		assert.Nil(t, err)
 		assert.Equal(t, `{"role_id":"bar","secret_id":"foo"}`, string(sentBody))
 


### PR DESCRIPTION
Since Go **1.16**, the **io/ioutil** package has been deprecated (see: [Go 1.16 Release Notes](https://golang.google.cn/doc/go1.16)). Even though the old package, which currently is more of a proxy package, is still available for backward compatibility, it's _preferable_ to use the affected functions directly from the new packages.

Thus, update current users of the **io/ioutil** package so that each uses its respective new package, either **os** or **io**, and then remove **io/ioutil** altogether.

No change to functionality intended.